### PR TITLE
Prevent endless subordinate entity loops

### DIFF
--- a/src/ofcli/fedtree.py
+++ b/src/ofcli/fedtree.py
@@ -37,6 +37,8 @@ class FedTree:
                             entity_id=URL(sub), http_session=http_session
                         )
                     )
+                    if subordinate.entity.get('sub') == self.entity.get('sub'):
+                        raise InternalException(f"Entity is listed as its own subordinate.")
                     await subordinate.discover(http_session)
                     # logger.debug(f"Adding subordinate {subordinate.entity.get('sub')}")
                     # logger.debug(f"{subordinate.entity}")


### PR DESCRIPTION
In case an entity lists itself as a subordinate entity at the `federation_list_endpoint`, ofcli crashes (maximum recursion depth). This PR adds a simple check that handles such ill-configured entities. Tested locally and remotely against the Italian government federation.