### PR TITLE
Set timestamp to instance creation time instead of class

### DIFF
--- a/src/ofcli/utils.py
+++ b/src/ofcli/utils.py
@@ -116,10 +116,10 @@ class URL:
 class EntityStatementPlus(EntityStatement):
     _jwt: str
 
-    def __init__(self, jwt: str, timestamp: int = int(time.time())):
+    def __init__(self, jwt: str):
         super().__init__(**get_payload(jwt))
         self._jwt = jwt
-        self._request_timestamp = timestamp
+        self._request_timestamp = int(time.time())
 
     @property
     def request_timestamp(self) -> int:


### PR DESCRIPTION
Title says it all, otherwise all entities have the same timestamp, irrespective of retrieval time.