### PR TITLE
Accept JWTs with any cty header parameter

### DIFF
--- a/src/ofcli/utils.py
+++ b/src/ofcli/utils.py
@@ -247,9 +247,12 @@ def get_payload(jws_str: str) -> dict:
     if not payload:
         raise InternalException("Could not parse entity configuration payload.")
     if not isinstance(payload, dict):
-        raise InternalException(
-            "Entity configuration payload is not a mapping: %s" % payload
-        )
+        try:
+            payload = json.loads(payload)
+        except ValueError:
+            raise InternalException(
+                "Entity configuration payload is not a mapping: %s" % payload
+            )
 
     return payload
 


### PR DESCRIPTION
ofcli uses the cryptojwt library which has a strict check on the `cty` header claim.
Values other than `jwt` (case-insensitive) are not accepted, instead, the payload is returned as a string, and then discarded.
This can result in lots of debug output, and lots of "lost" data.
This PR relaxes this restriction: If the payload is a valid JSON, it is accepted regardless of the `cty` header claim.
Such entities can easily be filtered or discarded during post-processing of the data.