### PR TITLE
Fix tc json output on cli

### DIFF
--- a/src/ofcli/trustchain.py
+++ b/src/ofcli/trustchain.py
@@ -252,8 +252,10 @@ def print_trustchains(chains: List[TrustChain], details: bool):
         logger.warn("No trust chains found.")
         return
     if details:
-        for chain in chains:
-            print_json(chain.to_json())
+        response = {}
+        for i, chain in enumerate(chains):
+            response[f"chain {i}"] = chain.to_json()
+        print_json(response)
     else:
         for chain in chains:
             click.echo("* " + str(chain))


### PR DESCRIPTION
In case multiple chains can be constructed, the output on the CLI differs from the API, as each chain is just appended to the next, resulting in broken json.

This PR aligns the CLI to the API output, i.e., returning valid JSON.